### PR TITLE
Fixed IdCode to IDCode to get Lithuanian Mobile-ID working

### DIFF
--- a/lib/digidoc/client.rb
+++ b/lib/digidoc/client.rb
@@ -59,7 +59,7 @@ module Digidoc
         locals.message 'CountryCode' => country_code, 'PhoneNo' => phone, 'Language' => language, 'ServiceName' => service_name,
           'MessageToDisplay' => message_to_display, 'SPChallenge' => sp_challenge, 'MessagingMode' => messaging_mode,
           'AsyncConfiguration' => async_configuration, 'ReturnCertData' => return_cert_data,
-          'ReturnRevocationData' => return_revocation_data, 'IdCode' => personal_code
+          'ReturnRevocationData' => return_revocation_data, 'IDCode' => personal_code
       end
 
       if soap_fault?(response)


### PR DESCRIPTION
Tere,

Tänud digidoc cliendi loomise eest!

Leedus on nõutud IDCode (http://sk-eid.github.io/dds-documentation/api/api_docs/) aga gemis on täheviga, mis ei edasta IDCode korrektselt. IdCode peab olema IDCode. Peale seda parandust sain Leedu sisselogimise tööle.

Suured tänud,

Jõudu,
Priit

